### PR TITLE
Fixes compatibility with MySQL sql_require_primary_key=ON

### DIFF
--- a/includes/features/class-schema.php
+++ b/includes/features/class-schema.php
@@ -206,7 +206,7 @@ class Schema {
 		$sql            .= " `id` varchar(100) NOT NULL DEFAULT '-',";
 		$sql            .= " `items` int(11) UNSIGNED NOT NULL DEFAULT '0',";
 		$sql            .= " `size` int(11) UNSIGNED NOT NULL DEFAULT '0',";
-		$sql            .= ' UNIQUE KEY u_stat (timestamp, id)';
+		$sql            .= ' PRIMARY KEY (`timestamp`, `id`)';
 		$sql            .= ") $charset_collate;";
 		// phpcs:ignore
 		$wpdb->query( $sql );


### PR DESCRIPTION
We had an issue installing this on a website using DigitalOcean Managed MySQL due to hosted database running with sql_require_primary_key=ON. 

This amends create schema to use `PRIMARY KEY` instead of `UNIQUE KEY`

For additional context: sql_require_primary_key=ON  is preferred as it helps with node migration/ replications in complex topologies or managed environments (e.g. DO) where it can not be disabled or is not recommended.